### PR TITLE
Docs source parameter ENTSO time_key

### DIFF
--- a/documentation/1-source_sensor.md
+++ b/documentation/1-source_sensor.md
@@ -47,7 +47,7 @@ If your provider is missing, you can create a Pull Request to add them, or creat
 
 |Data Provider|parameters|comment|
 |---|---|---|
-|[ENTSO-E](<https://github.com/JaccoR/hass-entso-e>)|`attr_today='prices_today', attr_tomorrow='prices_tomorrow', date_key='time', value_key='price'`||
+|[ENTSO-E](<https://github.com/JaccoR/hass-entso-e>)|`attr_today='prices_today', attr_tomorrow='prices_tomorrow', time_key='time', value_key='price'`||
 |[Nordpool](<https://github.com/custom-components/nordpool>)||all set by default|
 |[Tibber](<https://github.com/Danielhiversen/home_assistant_tibber_custom>)|`attr_today='today', attr_tomorrow='tomorrow', datetime_in_data=false`|This uses the custom component, not the core integration|
 |[Zonneplan](<https://github.com/fsaris/home-assistant-zonneplan-one>)|`attr_all='forecast', value_key='electricity_price'`||


### PR DESCRIPTION
changed parameter name in docs 
 from date_key to time_key

TypeError: macro 'cheapest_energy_hours' takes no keyword argument 'date_key’