### PR TITLE
Add config example for Amber Electric

### DIFF
--- a/documentation/1-source_sensor.md
+++ b/documentation/1-source_sensor.md
@@ -53,6 +53,7 @@ If your provider is missing, you can create a Pull Request to add them, or creat
 |[Nordpool](<https://github.com/custom-components/nordpool>)||all set by default|
 |[Tibber](<https://github.com/Danielhiversen/home_assistant_tibber_custom>)|`attr_today='today', attr_tomorrow='tomorrow', datetime_in_data=false`|This uses the custom component, not the core integration|
 |[Zonneplan](<https://github.com/fsaris/home-assistant-zonneplan-one>)|`attr_all='forecast', value_key='electricity_price'`||
+|[Amber Electric](https://www.home-assistant.io/integrations/amberelectric/)|`attr_all='forecasts', time_key='start_time', value_key='per_kwh'`||
 
 ## CREATING A FORECAST SENSOR USING THE SERVICE CALL
 


### PR DESCRIPTION
Documents the required configuration to use the [Amber Electric](https://www.home-assistant.io/integrations/amberelectric/) integration, which exposes a "general forecast" sensor with a `forecasts` attribute. That attribute is an array of objects structured like:

```json
  {
    "duration": 30.0,
    "date": "2024-06-10",
    "nem_date": "2024-06-10T12:30:00+10:00",
    "per_kwh": 0.17,
    "spot_per_kwh": 0.02,
    "start_time": "2024-06-10T02:00:01+00:00",
    "end_time": "2024-06-10T02:30:00+00:00",
    "renewables": 47,
    "spike_status": "none",
    "descriptor": "very_low"
  }
```