### PR TITLE
Allow direct input of price data

### DIFF
--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -1,4 +1,4 @@
-{%- set _version = 'v5.5.4'-%}
+{%- set _version = 'v6.0.0'-%}
 
 {#- sub-macro to format datetimes to selected time_format -#}
 {%- macro _format_date(datetime, time_format) -%}
@@ -99,6 +99,7 @@
 {#- main macro -#}
 {%- macro cheapest_energy_hours(
                                     sensor,
+                                    price_data,
                                     value_on_error,
                                     hours,
                                     start='00:00',
@@ -136,6 +137,7 @@
         {%- if debug -%}
             {%- set defaults = dict(
                                         sensor=none,
+                                        price_data=[],
                                         value_on_error=none,
                                         hours=none,
                                         start='00:00',
@@ -168,6 +170,7 @@
             -%}
             {%- set user_input = dict(
                                         sensor=sensor | default(none),
+                                        price_data=price_data | default(none),
                                         value_on_error= value_on_error | default(none),
                                         hours=hours | default(none) | round(3, default=none),
                                         start=start.isoformat() if start is datetime else start,
@@ -201,15 +204,15 @@
             {%- set non_default = dict(user_input.items() | reject('in', defaults.items())) -%}
         {%- endif -%}
     {#- find sensor if needed -#}
-        {%- if sensor is not defined or not sensor | has_value -%}
+        {%- if price_data is not defined and (sensor is not defined or not sensor | has_value) -%}
             {%- set sensor = _find_sensor(attr_today, attr_tomorrow) -%}
         {%- endif -%}
-        {%- if sensor | has_value -%}
+        {%- set day = timedelta(days=1) -%}
+        {%- if price_data is undefined and sensor | has_value -%}
         {#- Get data out of the selected entity, find right attributes if needed -#}
             {%- set today = state_attr(sensor, attr_today) | default([], true)-%}
             {%- set tomorrow = state_attr(sensor, attr_tomorrow) | default([], true) -%}
             {%- set all = state_attr(sensor, attr_all) | default([], true) -%}
-            {%- set day = timedelta(days=1) -%}
         {# check data if data_type is set to datetimes and values #}
             {%- if datetime_in_data | bool(true) -%}
             {# Check if there is an all attribute in the sensor #}
@@ -281,7 +284,22 @@
                 {%- endfor -%}
                 {%- set data = ns.data -%}
             {%- endif -%}
+        {%- elif price_data is defined
+            and price_data is list
+            and 
+                (
+                    price_data | count == 0
+                    or price_data[0] is mapping
+                )
+        -%}
+            {%- set data = price_data -%}
+            {%- set valid_price_data = true -%}
+        {%- elif price_data is defined -%}
+            {%- set data = [] -%}
+            {%- set valid_price_data = false -%}
+        {%- endif -%}
         {#- check if sensor has valid data -#}
+        {%- if data is defined -%}
             {%- if data | count > 0 and time_key in data[0] and value_key in data[0] -%}
             {#- Rebuild data from sensor to generic format -#}
                 {%- if data[0][time_key] is not datetime -%}
@@ -308,7 +326,7 @@
             {#- set number of hours based on weight points in case hours setting is not provided -#}
                 {%- if mode == 'extreme_now' -%}
                     {%- set h = 1 / dph -%}
-                {%- elif w and hours is not defined -%}
+                {%- elif w and hours is undefined -%}f
                     {%- set h = (w | count / no_weight_points | default(1)) -%}
                 {%- else -%}
                     {%- set h = hours | default(1) | float(1) -%}
@@ -401,7 +419,8 @@
     {#- set more data for debugging -#}
         {%- if debug -%}
             {%- set macro_input = dict(
-                                        sensor=sensor,
+                                        sensor=sensor | default(none),
+                                        price_data=price_data | default([]),
                                         hours=h | default(hours |default(1, true) | float(1)) | round(3),
                                         value_on_error= value_on_error | default(none),
                                         start=start.isoformat() if start is datetime else start,
@@ -441,12 +460,13 @@
         {%- set h = h | default(hours |default(1, true) | float(1)) | round(3) -%}
         {%- set start_end = start > end -%}
         {%- set end_start = ((end-start).total_seconds() / 3600) | round(3) if start is datetime and end is datetime else h -%}
-        {%- set valid_sensor = sensor | has_value %}
+        {%- set valid_sensor = sensor | default('unknown') | has_value -%}
         {%- set valid_pt = (price_tolerance is string and price_tolerance[-1] == '%' and price_tolerance[:-1] | is_number) or price_tolerance | is_number%}
         {%- set all_keys = iif(data) and time_key in data and value_key in data -%}
         {%- set errors = [
-                            "No valid sensor found" if not valid_sensor,
-                            "No valid data in {}".format(sensor) if data == [] and valid_sensor,
+                            "No valid sensor found" if price_data is undefined and not valid_sensor,
+                            "No valid data in {}".format(sensor) if price_data is undefined and data == [] and valid_sensor,
+                            "No valid data in provided price_data" if price_data is defined and not valid_price_data,
                             "Time key '{}' not found in data".format(time_key) if data and time_key not in data[0],
                             "Value key '{}' not found in data".format(value_key) if data and value_key not in data[0],
                             "Invalid mode '{}' selected".format(mode) if mode not in modes,
@@ -716,7 +736,7 @@
                             {%- set output.extreme_now = current_price is not none and current_price <= compare_price if lowest else current_price >= compare_price -%}
                         {#- output date based on the selected mode -#}
                             {%- if mode == 'all' -%}
-                                {%- set macro_output = dict(
+                                {%- set output = dict(
                                                         start=output.start,
                                                         end=output.end,
                                                         min=output.min,
@@ -742,15 +762,23 @@
                 {%- else -%}
                     {%- set v = values | count -%}
                     {%- set h_v = v / no_weight_points | round(3) -%}
-                    {%- set error_msg = '1 error: {} datapoints ({} hours) in selection, where {} ({} hours) are expected'.format(v, h_v, dp, h | round(3)) -%}
-                    {%- set macro_output = value_on_error if use_voe and not debug else error_msg -%}
+                    {%- set error_msg = '1 error: {} datapoints ({} hours) in selection, where {} ({} hours) are expected'.format(v | int, h_v | round(3), dp | int, h | round(3)) -%}
+                    {%- set macro_output = (value_on_error if use_voe and not debug else error_msg) | to_json -%}
                 {%- endif -%}
                 {%- if debug -%}
-                    {%- set dict_add = dict(values_count=values|count, datapoints_source=datapoints_source, datapoints_used=datapoints_used, original_prices=output.prices_list, price_count=price_count, kwh_list=kwh_list) -%}
+                    {%- set dict_add = dict(
+                                            values_count=values|count,
+                                            datapoints_source=datapoints_source,
+                                            datapoints_used=datapoints_used,
+                                            original_prices=(output | default({})).get('prices_list', []),
+                                            price_count=price_count | default(0),
+                                            kwh_list=kwh_list | default([])
+                                        )
+                    -%}
                     {{- dict(
                                 version=_version,
-                                output=macro_output,
-                                error=true if error_msg is defined else false,
+                                output=macro_output | from_json,
+                                error=error_msg is defined,
                                 non_default_user_input=non_default,
                                 set_by_macro=set_by_macro,
                                 defaults_used=defaults_used,

--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -735,7 +735,7 @@
                             {%- set output.extreme_now = current_price is not none and current_price <= compare_price if lowest else current_price >= compare_price -%}
                         {#- output date based on the selected mode -#}
                             {%- if mode == 'all' -%}
-                                {%- set output = dict(
+                                {%- set macro_output = dict(
                                                         start=output.start,
                                                         end=output.end,
                                                         min=output.min,
@@ -769,7 +769,7 @@
                                             values_count=values|count,
                                             datapoints_source=datapoints_source,
                                             datapoints_used=datapoints_used,
-                                            original_prices=(output | default({})).get('prices_list', []),
+                                            original_prices=output.prices_list,
                                             price_count=price_count | default(0),
                                             kwh_list=kwh_list | default([])
                                         )

--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -302,7 +302,7 @@
         {%- if data is defined -%}
             {%- if data | count > 0 and time_key in data[0] and value_key in data[0] -%}
             {#- Rebuild data from sensor to generic format -#}
-                {%- if data[0][time_key] is not datetime -%}
+                {%- if data[0][time_key] is not datetime or or price_factor != 1 -%}
                     {%- set rebuild = namespace(data=[]) -%}
                     {%- for item in data -%}
                         {%- set time = item[time_key] -%}
@@ -556,7 +556,7 @@
                     {%- endif -%}
                     {%- set split = mode == 'split' or split -%}
                     {%- set pr = precision | default(5) -%}
-                    {%- if split -%}
+                    {%- if split -%} {#- start of calculations for split -#}
                         {#- sort values and take out hours needed -#}
                             {%- set prices = (values | sort(attribute=value_key, reverse=not lowest) | map(attribute=value_key) | list)[:dp] -%}
                             {%- set values = values | selectattr(value_key, 'in', prices) | sort(attribute=time_key) | list -%}
@@ -661,8 +661,8 @@
                             -%} 
                         {#- output the data -#}
                             {%- set macro_output = output.all if mode == 'split' else output[mode] -%}
-                    {%- else -%}
-                        {#- create output for all modes -#}
+                    {%- else -%} {#- end for calucations for split -#}
+                        {#- create output for all modes if split is set to false -#}
                             {%- set output = namespace(average=none, start=none, min=none, max=none, weighted_average=none, compare=none, time_min=none, time_max=none, prices_list=[], list=[], is_now=false, extreme_now=none, estimated_costs="unknown") -%}
                             {%- set last_values = (h * no_weight_points) | round(0) | int -%}
                             {%- for i in range(values | count - (last_values - 1)) -%}
@@ -674,14 +674,14 @@
                                 -%}
                                 {#- calculate (weighted) average price -#}
                                     {%- if w is not none -%}
-                                        {%- set weighted = namespace(sum=0, original=0) -%}
-                                        {%- for price in prices_list -%}
-                                            {%- set weighted.sum = weighted.sum + price * w[loop.index0] -%}
+                                        {%- set weighted = namespace(average=0, original=0) -%}
+                                        {%- for weight in w -%}
+                                            {%- set weighted.average = weighted.average + (weight / w | sum) * prices_list[loop.index0] -%}
                                         {%- endfor -%}
-                                        {%- set a = weighted.sum / w | count -%}
+                                        {%- set a = weighted.average -%}
                                         {%- if pt != 0 -%}
-                                            {%- for price in original_price_list -%}
-                                                {%- set weighted.original = weighted.original + price * w[loop.index0] -%}
+                                            {%- for weight in w -%}
+                                                {%- set weighted.original = weighted.original + (weight / w | sum) + orignal_prices_list[loop.index0] -%}
                                             {%- endfor -%}
                                             {%- set original_w_avg = weighted.original / w | count -%}
                                         {%- endif -%}

--- a/documentation/1-source_sensor.md
+++ b/documentation/1-source_sensor.md
@@ -51,6 +51,7 @@ If your provider is missing, you can create a Pull Request to add them, or creat
 |[EasyEnergy](<https://www.home-assistant.io/integrations/easyenergy/>)|Yes|`time_key='timestamp'`|Using the template sensor [below](#energyzero-and-easyenergy)|
 |[EnergyZero](<https://www.home-assistant.io/integrations/energyzero/>)|Yes|`time_key='timestamp'`|Using the template sensor [below](#energyzero-and-easyenergy)|
 |[ENTSO-E](<https://github.com/JaccoR/hass-entso-e>)|No|`attr_today='prices_today', attr_tomorrow='prices_tomorrow', time_key='time', value_key='price'`||
+|[Frank Energie](<https://github.com/bajansen/home-assistant-frank_energie>)|No|`attr_all='prices', time_key='from', value_key='price'`||
 |[Octopus Energy](<https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy>)|No|`attr_all='rates', value_key='value_incl_vat'`||
 |[Omie](<https://github.com/luuuis/hass_omie>)|No||Using the template sensor [below](#omie)|
 |[Nordpool](<https://github.com/custom-components/nordpool>)|No||all set by default|


### PR DESCRIPTION
Allow directly input the price data in the macro, instead of relying on a sensor. This allows to create trigger based template sensors to be created directly based on the action response.

Example:
```yaml
template:
  - triggers:
      - trigger: time_pattern
        hours: "/1"
      - trigger: homeassistant
        event: start
      - trigger: state
        entity_id: binary_sensor.dishwasher_remote_start
        to: "on"
    action:
      - action: energyzero.get_energy_prices
        data:
          config_entry: fe7bdc80dd3bc850138998d869f1f19d
          incl_vat: false
          start: "{{ today_at('00:00') - timedelta(days=1) }}"
          end: "{{ today_at('00:00') + timedelta(days=2) }}"
        response_variable: price_data
    sensor:
      - unique_id: ad54a74b-9485-42f1-aeb2-519efdc79be5
        name: Dishwasher Start time
        device_class: timestamp
        icon: mdi:dishwasher
        state: >
          {% from 'cheapest_energy_hours.jinja' import cheapest_energy_hours %}
          {% set end = today_at('00:00') + timedelta(days = 1 if now() < today_at('20:30') else 2) %}
          {{ cheapest_energy_hours(
                                    hours=3.5,
                                    price_data=price_data.prices,
                                    value_key='price',
                                    time_key='timestamp',
                                    start=now(),
                                    value_on_error=today_at('00:00')
                                  )
          }}
```

TODO:
Update documentation