### PR TITLE
Zonneplan 15-min intervals support

### DIFF
--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -1,4 +1,4 @@
-{%- set _version = 'v7.2.3'-%}
+{%- set _version = 'v7.2.4'-%}
 
 {#- set settings for source sensors -#}
 {#- list values are 'attr_today', 'attr_tomorrow', 'attr_all', 'time_key', 'value_key' -#}

--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -395,15 +395,16 @@
             {%- set data = [] -%}
             {%- set valid_price_data = false -%}
         {%- endif -%}
-        {#- normalize zonneplan data to support both old (electricity_price/datetime) and new (price_tax_included.amount/start_date) API formats -#}
         {%- if source_settings == 'zonneplan' and data is defined and data | count > 0 and data[0] is mapping -%}
-            {%- if 'electricity_price' not in data[0] or time_key not in data[0] -%}
+            {%- if value_key not in data[0] or time_key not in data[0] -%}
                 {%- set ns_zp = namespace(data=[]) -%}
-                {%- for item in data -%}
+                {%- for item in data if item is mapping -%}
                     {%- set zp_time = item.get('start_date', item.get('datetime', item.get(time_key))) -%}
                     {%- set zp_price_nested = item.get('price_tax_included') -%}
                     {%- set zp_price = item.get('electricity_price', zp_price_nested.get('amount') if zp_price_nested is mapping else none) -%}
-                    {%- set ns_zp.data = ns_zp.data + [{time_key: zp_time, 'electricity_price': zp_price}] -%}
+                    {%- if zp_time | as_datetime(none) is not none and zp_price | is_number -%}
+                        {%- set ns_zp.data = ns_zp.data + [{time_key: zp_time, value_key: zp_price}] -%}
+                    {%- endif -%}
                 {%- endfor -%}
                 {%- set data = ns_zp.data -%}
             {%- endif -%}

--- a/cheapest_energy_hours.jinja
+++ b/cheapest_energy_hours.jinja
@@ -395,6 +395,19 @@
             {%- set data = [] -%}
             {%- set valid_price_data = false -%}
         {%- endif -%}
+        {#- normalize zonneplan data to support both old (electricity_price/datetime) and new (price_tax_included.amount/start_date) API formats -#}
+        {%- if source_settings == 'zonneplan' and data is defined and data | count > 0 and data[0] is mapping -%}
+            {%- if 'electricity_price' not in data[0] or time_key not in data[0] -%}
+                {%- set ns_zp = namespace(data=[]) -%}
+                {%- for item in data -%}
+                    {%- set zp_time = item.get('start_date', item.get('datetime', item.get(time_key))) -%}
+                    {%- set zp_price_nested = item.get('price_tax_included') -%}
+                    {%- set zp_price = item.get('electricity_price', zp_price_nested.get('amount') if zp_price_nested is mapping else none) -%}
+                    {%- set ns_zp.data = ns_zp.data + [{time_key: zp_time, 'electricity_price': zp_price}] -%}
+                {%- endfor -%}
+                {%- set data = ns_zp.data -%}
+            {%- endif -%}
+        {%- endif -%}
         {#- check if sensor has valid data -#}
         {%- if data is defined -%}
             {%- if data | count > 0 and time_key in data[0] and value_key in data[0] -%}

--- a/documentation/1-source_data.md
+++ b/documentation/1-source_data.md
@@ -65,7 +65,7 @@ If your provider is missing, you can create a Pull Request to add them, or creat
 |[Spain electriciy hourly pricing (PVPC)](<https://www.home-assistant.io/integrations/pvpc_hourly_pricing/>)|Yes||Using the template sensor [below](#spain-electricity-hourly-pricing-pvpc)|
 |[Tibber (core)](https://www.home-assistant.io/integrations/tibber/)|Yes|||Using the [blueprint](./blueprints/energy_price_sensor.md)|
 |[Tibber (custom)](<https://github.com/Danielhiversen/home_assistant_tibber_custom>)|No||`attr_today='today', attr_tomorrow='tomorrow', datetime_in_data=false`|This uses the custom component, not the core integration|
-|[Zonneplan](<https://github.com/fsaris/home-assistant-zonneplan-one>)|No|`zonneplan`|`attr_all='forecast', value_key='electricity_price'`||
+|[Zonneplan](<https://github.com/fsaris/home-assistant-zonneplan-one>)|No|`zonneplan`|`attr_all='forecast', value_key='electricity_price'`|Supports both old format (`electricity_price`/`datetime` keys) and new format (`price_tax_included.amount`/`start_date` keys, 15-minute intervals). The new integration uses sensor `sensor.zonneplan_current_quarter_hourly_electricity_tariff`|
 
 ## USING THE ACTION RESPONSE AS INPUT FOR THE MACRO
 


### PR DESCRIPTION
This pull request improves support for the Zonneplan energy provider by enhancing data parsing in the `cheapest_energy_hours.jinja` template and updating the documentation to clarify compatibility with both old and new data formats.

Template logic improvements for Zonneplan data:

* Added a block in `cheapest_energy_hours.jinja` to handle both the old and new Zonneplan data formats, extracting the correct time and price keys depending on the data structure. This ensures compatibility with Zonneplan's updated API, which uses nested keys and 15-minute intervals.

Documentation updates:

* Updated the Zonneplan entry in `documentation/1-source_data.md` to explain support for both old (`electricity_price`/`datetime`) and new (`price_tax_included.amount`/`start_date`) data formats, and to mention the new integration sensor name.

Fixes  #273.